### PR TITLE
Use 'an' rather than 'a' as the article where the time difference is a single hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Also you can use second argument as a from date:
 
 ```ruby
 date_from = Time.now - 60 * 60 # one hour ago
-RelativeTime.in_words(Time.now, date_from)          # => a hour ago
+RelativeTime.in_words(Time.now, date_from)          # => an hour ago
 ```
 
 ### Supported intervals
@@ -57,4 +57,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/davydo
 
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/relative_time/in_words.rb
+++ b/lib/relative_time/in_words.rb
@@ -34,7 +34,7 @@ module RelativeTime
 
     def verb_agreement(resolution)
       if resolution[0] == 1 && resolution.last == 'hours'
-        "an hour"
+        'an hour'
       elsif resolution[0] == 1
         "a #{resolution.last[0...-1]}"
       else

--- a/lib/relative_time/in_words.rb
+++ b/lib/relative_time/in_words.rb
@@ -33,7 +33,9 @@ module RelativeTime
     end
 
     def verb_agreement(resolution)
-      if resolution[0] == 1
+      if resolution[0] == 1 && resolution.last == 'hours'
+        "an hour"
+      elsif resolution[0] == 1
         "a #{resolution.last[0...-1]}"
       else
         resolution.join(' ')

--- a/test/relative_time_test.rb
+++ b/test/relative_time_test.rb
@@ -13,7 +13,7 @@ describe RelativeTime do
   describe '#in_words' do
     describe 'with from date' do
       let(:date_from) { Time.now + 1 * hour }
-      it { RelativeTime.in_words(date, date_from).must_equal 'a hour ago' }
+      it { RelativeTime.in_words(date, date_from).must_equal 'an hour ago' }
 
       describe 'with both DateTime type' do
         let(:date) { DateTime.new(2017, 1, 15, 11, 0) }
@@ -35,7 +35,7 @@ describe RelativeTime do
       end
     end
 
-    describe 'when differense in seconds' do
+    describe 'when difference in seconds' do
       it { RelativeTime.in_words(date).must_equal      'less than a minute' }
 
       it { RelativeTime.in_words(date - 10).must_equal 'less than a minute' }
@@ -45,7 +45,7 @@ describe RelativeTime do
       it { RelativeTime.in_words(date + 59).must_equal 'less than a minute' }
     end
 
-    describe 'when differense in minutes' do
+    describe 'when difference in minutes' do
       it { RelativeTime.in_words(date - 70).must_equal 'a minute ago' }
       it { RelativeTime.in_words(date + 70).must_equal 'in a minute' }
 
@@ -60,25 +60,25 @@ describe RelativeTime do
       it { RelativeTime.in_words(date + 59 * minute).must_equal 'in 59 minutes' }
     end
 
-    describe 'when differense in hours' do
-      it { RelativeTime.in_words(date - 70 * minute).must_equal  'a hour ago' }
-      it { RelativeTime.in_words(date + 70 * minute).must_equal  'in a hour' }
+    describe 'when difference in hours' do
+      it { RelativeTime.in_words(date - 70 * minute).must_equal  'an hour ago' }
+      it { RelativeTime.in_words(date + 70 * minute).must_equal  'in an hour' }
 
-      it { RelativeTime.in_words(date - 60 * minute).must_equal  'a hour ago' }
-      it { RelativeTime.in_words(date + 60 * minute).must_equal  'in a hour' }
+      it { RelativeTime.in_words(date - 60 * minute).must_equal  'an hour ago' }
+      it { RelativeTime.in_words(date + 60 * minute).must_equal  'in an hour' }
 
-      it { RelativeTime.in_words(date - 1  * hour).must_equal  'a hour ago' }
+      it { RelativeTime.in_words(date - 1  * hour).must_equal  'an hour ago' }
       it { RelativeTime.in_words(date - 3  * hour).must_equal  '3 hours ago' }
       it { RelativeTime.in_words(date - 10 * hour).must_equal '10 hours ago' }
       it { RelativeTime.in_words(date - 23 * hour).must_equal '23 hours ago' }
 
-      it { RelativeTime.in_words(date + 1  * hour).must_equal 'in a hour' }
+      it { RelativeTime.in_words(date + 1  * hour).must_equal 'in an hour' }
       it { RelativeTime.in_words(date + 3  * hour).must_equal 'in 3 hours' }
       it { RelativeTime.in_words(date + 10 * hour).must_equal 'in 10 hours' }
       it { RelativeTime.in_words(date + 23 * hour).must_equal 'in 23 hours' }
     end
 
-    describe 'when differense in days' do
+    describe 'when difference in days' do
       it { RelativeTime.in_words(date - 24 * hour).must_equal  'a day ago' }
       it { RelativeTime.in_words(date + 24 * hour).must_equal  'in a day' }
 
@@ -91,7 +91,7 @@ describe RelativeTime do
       it { RelativeTime.in_words(date + 6 * day).must_equal 'in 6 days' }
     end
 
-    describe 'when differense in weeks' do
+    describe 'when difference in weeks' do
       it { RelativeTime.in_words(date - 7 * day).must_equal  'a week ago' }
       it { RelativeTime.in_words(date + 7 * day).must_equal  'in a week' }
 
@@ -105,7 +105,7 @@ describe RelativeTime do
       it { RelativeTime.in_words(date + 3 * week).must_equal 'in 3 weeks' }
     end
 
-    describe 'when differense in months' do
+    describe 'when difference in months' do
       it { RelativeTime.in_words(date - 4 * week).must_equal 'a month ago' }
       it { RelativeTime.in_words(date + 4 * week).must_equal 'in a month' }
 
@@ -119,7 +119,7 @@ describe RelativeTime do
       it { RelativeTime.in_words(date + 11 * month).must_equal 'in 11 months' }
     end
 
-    describe 'when differense in years' do
+    describe 'when difference in years' do
       it { RelativeTime.in_words(date - 12 * month).must_equal 'a year ago' }
       it { RelativeTime.in_words(date + 12 * month).must_equal 'in a year' }
 


### PR DESCRIPTION
First up, this is a great gem and perfect for my simple use case. 

In this PR I've changed the article used in cases where the time difference is a a single hour (`an hour` vs `a hour`), per [this answer](https://english.stackexchange.com/a/155) on the [English Language & Usage Stack Exchange](https://english.stackexchange.com/):

> The question of "a" vs "an" is always decided by the pronunciation of the word that follows the article. Thus, various geographical regions that have different pronunciation rules may use a different article for the same word.
> Words that begin with a vowel sound, such as "apple", "egg", or "hour" are preceded by "an".

I've also taken the opportunity to fix a couple of small typos.

Cheers!